### PR TITLE
ignore zope.interface.ro.C3 attributes which can continually add the ORIG_ prefix

### DIFF
--- a/pyloot/collector.py
+++ b/pyloot/collector.py
@@ -37,6 +37,15 @@ def _safe_repr(obj: object) -> str:
 
 def _safe_getattr(obj: object, k: str, default: Any = Exception):
     try:
+        from zope.interface.ro import C3
+
+        if isinstance(obj, C3) or issubclass(obj, C3):
+            if k.startswith("ORIG_"):
+                return "__ignored_zope_interface_C3_{}__".format(k)
+    except (ImportError, TypeError):
+        pass
+
+    try:
         return getattr(obj, k)
     except Exception as e:
         if default is Exception:


### PR DESCRIPTION
Some attributes of this particular class (likely brought in to most packages via gevent) has the following code:
```
class _ClassBoolFromEnv(object):
    """
    Non-data descriptor that reads a transformed environment variable
    as a boolean, and caches the result in the class.
    """

    def __get__(self, inst, klass):
        import os
        for cls in klass.__mro__:
            my_name = None
            for k in dir(klass):
                if k in cls.__dict__ and cls.__dict__[k] is self:
                    my_name = k
                    break
            if my_name is not None:
                break
        else: # pragma: no cover
            raise RuntimeError("Unable to find self")

        env_name = 'ZOPE_INTERFACE_' + my_name
        val = os.environ.get(env_name, '') == '1'
        val = _NamedBool(val, my_name)
        setattr(klass, my_name, val)
        setattr(klass, 'ORIG_' + my_name, self)
        return val
```

Every time an attribute of this type is accessed via `getattr` a new one is created with the `ORIG_` prefix. Since pyloot goes through each key via `dir on each collection, `getattr` is then called on `ORIG_ATTR` and then again on `ORIG_ORIG_ATTR` etc.