### PR TITLE
Fixes for Python3.9

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyloot/collector.py
+++ b/pyloot/collector.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 METHOD_TYPES = [
     type(tuple.__le__),  # 'wrapper_descriptor'
     type([1].__le__),  # 'method-wrapper'
-    type(sys.getcheckinterval),  # 'builtin_function_or_method'
+    type(sys.getswitchinterval),  # 'builtin_function_or_method'
     type(cgi.FieldStorage.getfirst),  # 'instancemethod'
     type(logger.addFilter),  # 'bound instancemethod'
 ]

--- a/pyloot/server.py
+++ b/pyloot/server.py
@@ -155,8 +155,12 @@ class PyLootServer:
         if req.path_info_peek() == "static":
             req.path_info_pop()
         logger.info("[static asset] %s", req.path_info)
-        with resources.path("pyloot", "static") as path:
-            return static.DirectoryApp(path)
+        try:
+            with resources.files("pyloot").joinpath("static") as path:
+                return static.DirectoryApp(path)
+        except AttributeError:
+            with resources.path("pyloot", "static") as path:
+                return static.DirectoryApp(path)
 
     def serve_forever(self, host: str = "0.0.0.0", port: int = 8000):
         httpd = simple_server.make_server(host, port, self)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 
 
 [testenv]


### PR DESCRIPTION
importlib.resources.path specifies that directories are not resources
and throws an error. Incorporated fix from Jaraco in
https://github.com/python/importlib_resources/issues/85

sys.getcheckinterval is deprecated as of 3.2, use sys.getswitchinterval
instead per
https://docs.python.org/3.8/library/sys.html#sys.getcheckinterval

Added 3.9 to Tox and Github Workflows to ensure testing was
accomplished.